### PR TITLE
make indep_coord_name keyword-only

### DIFF
--- a/src/stream_ml/core/base.py
+++ b/src/stream_ml/core/base.py
@@ -55,12 +55,11 @@ class ModelBase(Model[Array], CompiledShim, metaclass=ABCMeta):
         The bounds on the parameters.
     """
 
-    indep_coord_name: str = "phi1"  # TODO: move up class hierarchy?
-
     _: KW_ONLY
     array_namespace: InitVar[ArrayNamespace[Array]]
     name: str | None = None  # the name of the model
 
+    indep_coord_name: str = "phi1"  # TODO? allow this to be a tuple
     coord_names: tuple[str, ...]
     param_names: ParamNamesField = ParamNamesField()
 


### PR DESCRIPTION
Much easier arg inheritance.

Signed-off-by: nstarman <nstarkman@protonmail.com>


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
