### PR TITLE
refactor typing into module

### DIFF
--- a/src/stream_ml/core/api.py
+++ b/src/stream_ml/core/api.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from stream_ml.core.params.bounds import ParamBounds, ParamBoundsField
 from stream_ml.core.params.core import Params, freeze_params, set_param
 from stream_ml.core.params.names import ParamNamesField
-from stream_ml.core.typing import Array, ArrayNamespace
+from stream_ml.core.typing import Array, ArrayNamespace, NNModel
 from stream_ml.core.utils.frozen_dict import FrozenDict, FrozenDictField
 
 if TYPE_CHECKING:
@@ -21,12 +21,22 @@ if TYPE_CHECKING:
 __all__: list[str] = []
 
 
-class Model(Protocol[Array]):
+class SupportsXP(Protocol[Array]):
+    """Protocol for objects that support array namespaces."""
+
+    _array_namespace_: ArrayNamespace[Array]
+
+    @property
+    def xp(self) -> ArrayNamespace[Array]:
+        """Array namespace."""
+        return self._array_namespace_
+
+
+class Model(SupportsXP[Array], Protocol[Array, NNModel]):
     """Model base class."""
 
     name: str | None
-    _array_namespace_: ArrayNamespace[Array]
-    _nn_namespace_: NNNamespace[Array]
+    _nn_namespace_: NNNamespace[NNModel, Array]
 
     # Name of the coordinates and parameters.
     coord_names: tuple[str, ...]
@@ -45,12 +55,7 @@ class Model(Protocol[Array]):
         ...
 
     @property
-    def xp(self) -> ArrayNamespace[Array]:
-        """Array namespace."""
-        return self._array_namespace_
-
-    @property
-    def xpnn(self) -> NNNamespace[Array]:
+    def xpnn(self) -> NNNamespace[NNModel, Array]:
         """NN namespace."""
         return self._nn_namespace_
 

--- a/src/stream_ml/core/multi/bases.py
+++ b/src/stream_ml/core/multi/bases.py
@@ -11,7 +11,7 @@ from stream_ml.core.api import Model
 from stream_ml.core.base import NN_NAMESPACE
 from stream_ml.core.params import ParamBounds, ParamNames, Params
 from stream_ml.core.setup_package import CompiledShim
-from stream_ml.core.typing import Array, ArrayNamespace, BoundsT
+from stream_ml.core.typing import Array, ArrayNamespace, BoundsT, NNModel
 from stream_ml.core.utils.frozen_dict import FrozenDict, FrozenDictField
 
 if TYPE_CHECKING:
@@ -23,7 +23,9 @@ if TYPE_CHECKING:
 __all__: list[str] = []
 
 
-def _get_namespace(components: FrozenDict[str, Model[Array]]) -> ArrayNamespace[Array]:
+def _get_namespace(
+    components: FrozenDict[str, Model[Array, NNModel]]
+) -> ArrayNamespace[Array]:
     """Get the array namespace."""
     ns = {v._array_namespace_ for v in components.values()}
     if len(ns) != 1:
@@ -34,11 +36,14 @@ def _get_namespace(components: FrozenDict[str, Model[Array]]) -> ArrayNamespace[
 
 @dataclass
 class ModelsBase(
-    Model[Array], Mapping[str, Model[Array]], CompiledShim, metaclass=ABCMeta
+    Model[Array, NNModel],
+    Mapping[str, Model[Array, NNModel]],
+    CompiledShim,
+    metaclass=ABCMeta,
 ):
     """Multi-model base class."""
 
-    components: FrozenDictField[str, Model[Array]] = FrozenDictField()
+    components: FrozenDictField[str, Model[Array, NNModel]] = FrozenDictField()
 
     _: KW_ONLY
     name: str | None = None  # the name of the model
@@ -129,7 +134,7 @@ class ModelsBase(
     # ===============================================================
     # Mapping
 
-    def __getitem__(self, key: str) -> Model[Array]:
+    def __getitem__(self, key: str) -> Model[Array, NNModel]:
         return self.components[key]
 
     def __iter__(self) -> Iterator[str]:

--- a/src/stream_ml/core/multi/independent.py
+++ b/src/stream_ml/core/multi/independent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from stream_ml.core.multi.bases import ModelsBase
 from stream_ml.core.params import ParamNames, Params
 from stream_ml.core.setup_package import WEIGHT_NAME
-from stream_ml.core.typing import Array
+from stream_ml.core.typing import Array, NNModel
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -19,7 +19,7 @@ __all__: list[str] = []
 
 
 @dataclass(unsafe_hash=True)
-class IndependentModels(ModelsBase[Array]):
+class IndependentModels(ModelsBase[Array, NNModel]):
     """Composite of a few models that acts like one model.
 
     This is different from a mixture model in that the components are not

--- a/src/stream_ml/core/multi/mixture.py
+++ b/src/stream_ml/core/multi/mixture.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 from stream_ml.core.multi.bases import ModelsBase
 from stream_ml.core.params import ParamNames, Params
 from stream_ml.core.setup_package import BACKGROUND_KEY, WEIGHT_NAME
-from stream_ml.core.typing import Array
+from stream_ml.core.typing import Array, NNModel
 from stream_ml.core.utils.frozen_dict import FrozenDictField
 
 __all__: list[str] = []
@@ -28,7 +28,7 @@ class TieParamsCallable(Protocol):
 
 
 @dataclass
-class MixtureModel(ModelsBase[Array]):
+class MixtureModel(ModelsBase[Array, NNModel]):
     """Full Model.
 
     Parameters

--- a/src/stream_ml/core/prior/base.py
+++ b/src/stream_ml/core/prior/base.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from stream_ml.core.api import Model
     from stream_ml.core.data import Data
     from stream_ml.core.params.core import Params
-    from stream_ml.core.typing import ArrayNamespace
+    from stream_ml.core.typing import ArrayNamespace, NNModel
 
 __all__: list[str] = []
 
@@ -32,7 +32,7 @@ class PriorBase(Generic[Array], metaclass=ABCMeta):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None = None,
         /,
         *,
@@ -67,7 +67,9 @@ class PriorBase(Generic[Array], metaclass=ABCMeta):
         """
         ...
 
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array], /) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel], /
+    ) -> Array:
         """Evaluate the forward step in the prior.
 
         Parameters

--- a/src/stream_ml/core/prior/bounds.py
+++ b/src/stream_ml/core/prior/bounds.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from stream_ml.core.params.names import FlatParamName  # noqa: TCH001
 from stream_ml.core.prior.base import PriorBase
-from stream_ml.core.typing import Array, ArrayNamespace, BoundsT
+from stream_ml.core.typing import Array, ArrayNamespace
 from stream_ml.core.utils.compat import array_at
 from stream_ml.core.utils.funcs import within_bounds
 
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from stream_ml.core.api import Model
     from stream_ml.core.data import Data
     from stream_ml.core.params.core import Params
+    from stream_ml.core.typing import BoundsT, NNModel
 
     Self = TypeVar("Self", bound="PriorBounds")  # type: ignore[type-arg]
 
@@ -39,7 +40,7 @@ class PriorBounds(PriorBase[Array]):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None = None,
         /,
         *,
@@ -56,7 +57,9 @@ class PriorBounds(PriorBase[Array]):
         ).set(-xp.inf)
 
     @abstractmethod
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array], /) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel], /
+    ) -> Array:
         """Evaluate the forward step in the prior."""
         ...
 
@@ -108,7 +111,7 @@ class NoBounds(PriorBounds[Any]):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None = None,
         /,
         *,
@@ -120,6 +123,8 @@ class NoBounds(PriorBounds[Any]):
             raise ValueError(msg)
         return 0
 
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array], /) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel], /
+    ) -> Array:
         """Evaluate the forward step in the prior."""
         return pred

--- a/src/stream_ml/core/prior/core.py
+++ b/src/stream_ml/core/prior/core.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from stream_ml.core.api import Model
     from stream_ml.core.data import Data
     from stream_ml.core.params.core import Params
+    from stream_ml.core.typing.nn import NNModel
 
 
 __all__: list[str] = []
@@ -24,7 +25,7 @@ class LogPDFHook(Protocol):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None,
         /,
         *,
@@ -37,7 +38,9 @@ class LogPDFHook(Protocol):
 class ForwardHook(Protocol):
     """Forward hook."""
 
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array], /) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel], /
+    ) -> Array:
         """Evaluate the forward step in the prior."""
         ...
 
@@ -53,7 +56,7 @@ class Prior(PriorBase[Array]):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None = None,
         /,
         *,
@@ -72,7 +75,7 @@ class Prior(PriorBase[Array]):
             parameters.
         data : Data[Array], position-only
             The data for which evaluate the prior.
-        model : Model[Array], position-only
+        model : Model[Array, NNModel], position-only
             The model for which evaluate the prior.
         current_lnpdf : Array | None, optional position-only
             The current logpdf, by default `None`. This is useful for setting
@@ -88,7 +91,9 @@ class Prior(PriorBase[Array]):
         """
         return self.logpdf_hook(mpars, data, model, current_lnpdf, xp=xp)
 
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array], /) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel], /
+    ) -> Array:
         """Evaluate the forward step in the prior.
 
         Parameters
@@ -97,7 +102,7 @@ class Prior(PriorBase[Array]):
             The input to evaluate the prior at.
         data : Data[Array]
             The data to evaluate the prior at.
-        model : Model[Array]
+        model : Model[Array, NNModel]
             The model to evaluate the prior at.
 
         xp : ArrayNamespace[Array], keyword-only

--- a/src/stream_ml/core/prior/weight.py
+++ b/src/stream_ml/core/prior/weight.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from stream_ml.core.api import Model
     from stream_ml.core.data import Data
     from stream_ml.core.params.core import Params
+    from stream_ml.core.typing import NNModel
 
 __all__: list[str] = []
 
@@ -44,7 +45,7 @@ class BoundedHardThreshold(PriorBase[Array]):
         self,
         mpars: Params[Array],
         data: Data[Array],
-        model: Model[Array],
+        model: Model[Array, NNModel],
         current_lnpdf: Array | None = None,
         /,
         *,
@@ -83,7 +84,9 @@ class BoundedHardThreshold(PriorBase[Array]):
         )
         return array_at(lnp, where).set(-xp.inf)
 
-    def __call__(self, pred: Array, data: Data[Array], model: Model[Array]) -> Array:
+    def __call__(
+        self, pred: Array, data: Data[Array], model: Model[Array, NNModel]
+    ) -> Array:
         """Evaluate the forward step in the prior.
 
         Parameters

--- a/src/stream_ml/core/typing/__init__.py
+++ b/src/stream_ml/core/typing/__init__.py
@@ -1,0 +1,13 @@
+"""Core feature."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from .array import Array, ArrayLike, ArrayNamespace
+from .nn import NNModel, NNNamespace
+
+__all__ = ["Array", "ArrayLike", "ArrayNamespace", "BoundsT", "NNNamespace", "NNModel"]
+
+
+BoundsT: TypeAlias = tuple[float, float]

--- a/src/stream_ml/core/typing/array.py
+++ b/src/stream_ml/core/typing/array.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, TypeAlias, TypeVar
+from typing import Any, Protocol, TypeVar
 
-__all__ = ["Array", "ArrayNamespace", "BoundsT"]
-
-
-BoundsT: TypeAlias = tuple[float, float]
+__all__: list[str] = []
 
 
 #####################################################################
@@ -123,6 +120,7 @@ class ArrayLike(Protocol):
 
 
 Array = TypeVar("Array", bound="ArrayLike")
+Array_co = TypeVar("Array_co", bound="ArrayLike", covariant=True)
 
 
 #####################################################################
@@ -221,23 +219,22 @@ class ArrayNamespace(Protocol[Array]):
         """Zeros like."""
         ...
 
-
-#####################################################################
-
-
-class NNIdentity(Protocol[Array]):
-    """Protocol for identity."""
-
     @staticmethod
-    def __call__(x: Array) -> Array:
-        """Call."""
+    def isneginf(array: Array) -> Array:
+        """Is negative infinity."""
         ...
 
-
-class NNNamespace(Protocol[Array]):
-    """Protocol for neural network API namespace."""
+    @staticmethod
+    def isposinf(array: Array) -> Array:
+        """Is positive infinity."""
+        ...
 
     @staticmethod
-    def Identity(*args: Any, **kwargs: Any) -> NNIdentity[Array]:  # noqa: N802
-        """Identity."""
+    def isinf(array: Array) -> Array:
+        """Is infinity."""
+        ...
+
+    @staticmethod
+    def sigmoid(array: Array) -> Array:
+        """Sigmoid."""
         ...

--- a/src/stream_ml/core/typing/nn.py
+++ b/src/stream_ml/core/typing/nn.py
@@ -1,0 +1,38 @@
+"""Core feature."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar
+
+from .array import Array, Array_co
+
+__all__: list[str] = []
+
+
+NNModel = TypeVar("NNModel")
+NNModel_co = TypeVar("NNModel_co", covariant=True)
+
+
+class NNNamespace(Protocol[NNModel_co, Array_co]):
+    """Protocol for neural network API namespace."""
+
+    @staticmethod
+    def Identity(  # noqa: N802
+        *args: Any, **kwargs: Any
+    ) -> (
+        NNModel_co | Identity[Array_co]
+    ):  # NOTE: this should be Intersection[NNModel, Array]
+        """Identity."""
+        ...
+
+
+# =============================================================================
+
+
+class Identity(Protocol[Array]):
+    """Protocol for identity."""
+
+    @staticmethod
+    def __call__(x: Array) -> Array:
+        """Call."""
+        ...


### PR DESCRIPTION
The typing file got a bit large. This PR refactors it into a module and provides deeper integration for the NN-Model, e.g. `torch.nn.Module` or `flx.linen.Model`.


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
