### PR TITLE
astype and apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,12 +121,16 @@ where = ["src"]
   plugins = ["numpy.typing.mypy_plugin",]
 
   [[tool.mypy.overrides]]
-    module = "*/tests/*"
+    module = [
+      "*/tests/*",
+      "tests/*"
+    ]
     ignore_errors = true
 
   [[tool.mypy.overrides]]
-    module = "tests/*"
+    module = "astropy.*"
     ignore_errors = true
+    ignore_missing_imports = true
 
 
 [tool.ruff]

--- a/src/stream_ml/core/_connect/data.py
+++ b/src/stream_ml/core/_connect/data.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-from stream_ml.core.data import FROM_FORMAT_REGISTRY, Data
+from stream_ml.core.data import FROM_FORMAT_REGISTRY, TO_FORMAT_REGISTRY, Data
 
 __all__: list[str] = []
 
@@ -56,12 +56,35 @@ def _from_structured_array(array: NDArray[Any], /, **kwargs: Any) -> Data[NDArra
     )
 
 
+def _to_format_structured_array(data: Data[NDArray[Any]], /) -> NDArray[Any]:
+    """Convert the data to a structured numpy array.
+
+    Requires :mod:`numpy` to be installed.
+
+    Parameters
+    ----------
+    data : Data
+        The data.
+
+    Returns
+    -------
+    ndarray
+        The structured array.
+    """
+    from numpy.lib.recfunctions import unstructured_to_structured
+
+    return cast(
+        "NDArray[Any]", unstructured_to_structured(data.array, names=data.names)
+    )
+
+
 try:
-    import numpy as np  # noqa: F401
+    import numpy as np
 except ImportError:
     pass
 else:
     FROM_FORMAT_REGISTRY["numpy.structured"] = _from_structured_array
+    TO_FORMAT_REGISTRY[(np.ndarray, np.ndarray)] = _to_format_structured_array
 
 
 #####################################################################


### PR DESCRIPTION
- Change ``to_format`` to `astype`. This transforms the data, keeping a `Data` object.
- Add `to_format`, the opposite of `from_format`.
- Add method `apply`. 


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
