### PR TITLE
names sets column order

### DIFF
--- a/src/stream_ml/core/_connect/data.py
+++ b/src/stream_ml/core/_connect/data.py
@@ -118,11 +118,9 @@ def _from_astropy_table(table: Table, /, **kwargs: Any) -> Data[NDArray[Any]]:
     Data
         The data instance.
     """
+    names = kwargs.pop("names", Ellipsis)
     return Data.from_format(
-        table.as_array(
-            keep_byteorder=kwargs.pop("keep_byteorder", False),
-            names=kwargs.pop("names", None),
-        ),
+        table[names].as_array(keep_byteorder=kwargs.pop("keep_byteorder", False)),
         fmt="numpy.structured",
         **kwargs,
     )


### PR DESCRIPTION
name in QTable from_format correctly sets column order.

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
