### PR TITLE
coord-bounds are unscaled data

### DIFF
--- a/src/stream_ml/core/base.py
+++ b/src/stream_ml/core/base.py
@@ -235,6 +235,8 @@ class ModelBase(Model[Array, NNModel], CompiledShim, metaclass=ABCMeta):
             Zero everywhere except where the data are outside the
             coordinate bounds, where it is -inf.
         """
+        data = self.data_scaler.inverse_transform(data, names=data.names)
+
         lnp = self.xp.zeros_like(mpars[(WEIGHT_NAME,)])
         where = reduce(
             self.xp.logical_or,


### PR DESCRIPTION
Closing in on having the log-likelihood run on the unscaled data.

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
