### PR TITLE
restore default None

### DIFF
--- a/src/stream_ml/core/_base.py
+++ b/src/stream_ml/core/_base.py
@@ -134,7 +134,7 @@ class ModelBase(Model[Array, NNModel], CompiledShim, metaclass=ABCMeta):
         a mixture model (see :class:`~stream_ml.core.core.MixtureModel`).
     """
 
-    net: NNField[NNModel] = NNField(default=MISSING)
+    net: NNField[NNModel] = NNField(default=None)
 
     _: KW_ONLY
     array_namespace: ArrayNamespace[Array]


### PR DESCRIPTION
The default should be None, to trigger the hook on the class.

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
