### PR TITLE
Component likelihood

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ ban-relative-imports = "all"
 
 [tool.ruff.isort]
 force-sort-within-sections = true
+combine-as-imports = true
 known-first-party = ["stream_ml"]
 known-third-party = ["numpy", "pytest"]
 

--- a/src/stream_ml/core/_api.py
+++ b/src/stream_ml/core/_api.py
@@ -1,4 +1,4 @@
-"""Core feature."""
+"""Establishing the probabilities API, largely free of any implementation."""
 
 from __future__ import annotations
 
@@ -123,7 +123,7 @@ class TotalLnProbabilities(Protocol[Array]):
     def ln_likelihood_tot(
         self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
-        """Total log-likelihood of the model.
+        """Sum of the log-likelihood.
 
         This is evaluated over the entire data set.
 
@@ -144,7 +144,7 @@ class TotalLnProbabilities(Protocol[Array]):
         ...
 
     def ln_prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
-        """Log prior.
+        """Sum of the log-prior.
 
         Parameters
         ----------
@@ -163,7 +163,7 @@ class TotalLnProbabilities(Protocol[Array]):
     def ln_posterior_tot(
         self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
-        """Log posterior.
+        """Sum of the log-posterior.
 
         Parameters
         ----------
@@ -259,7 +259,7 @@ class TotalProbabilities(Protocol[Array]):
     def likelihood_tot(
         self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
-        """Total likelihood of the model.
+        """Sum of the likelihood.
 
         This is evaluated over the entire data set.
 
@@ -280,7 +280,7 @@ class TotalProbabilities(Protocol[Array]):
         ...
 
     def prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
-        """Total prior.
+        """Sum of the prior.
 
         Parameters
         ----------
@@ -299,7 +299,7 @@ class TotalProbabilities(Protocol[Array]):
     def posterior_tot(
         self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
-        """Total posterior.
+        """Sum of the posterior.
 
         Parameters
         ----------
@@ -316,3 +316,15 @@ class TotalProbabilities(Protocol[Array]):
         Array
         """
         ...
+
+
+class AllProbabilities(
+    TotalProbabilities[Array],
+    Probabilities[Array],
+    TotalLnProbabilities[Array],
+    LnProbabilities[Array],
+    Protocol,
+):
+    """Protocol for objects that support probabilities."""
+
+    ...

--- a/src/stream_ml/core/_api.py
+++ b/src/stream_ml/core/_api.py
@@ -50,7 +50,7 @@ class LnProbabilities(Protocol[Array]):
     """Protocol for objects that support probabilities."""
 
     def ln_likelihood(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Any
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Any
     ) -> Array:
         """Elementwise log-likelihood of the model.
 
@@ -71,7 +71,11 @@ class LnProbabilities(Protocol[Array]):
         ...
 
     def ln_prior(
-        self, mpars: Params[Array], data: Data[Array], current_lnp: Array | None = None
+        self,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        current_lnp: Array | None = None,
     ) -> Array:
         """Elementwise log prior.
 
@@ -92,7 +96,7 @@ class LnProbabilities(Protocol[Array]):
         ...
 
     def ln_posterior(
-        self, mpars: Params[Array], data: Data[Array], **kw: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
         """Elementwise log posterior.
 
@@ -117,7 +121,7 @@ class TotalLnProbabilities(Protocol[Array]):
     """Protocol for objects that support total probabilities."""
 
     def ln_likelihood_tot(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         """Total log-likelihood of the model.
 
@@ -139,7 +143,7 @@ class TotalLnProbabilities(Protocol[Array]):
         """
         ...
 
-    def ln_prior_tot(self, mpars: Params[Array], data: Data[Array]) -> Array:
+    def ln_prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
         """Log prior.
 
         Parameters
@@ -157,7 +161,7 @@ class TotalLnProbabilities(Protocol[Array]):
         ...
 
     def ln_posterior_tot(
-        self, mpars: Params[Array], data: Data[Array], **kw: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
         """Log posterior.
 
@@ -182,7 +186,7 @@ class Probabilities(Protocol[Array]):
     """Protocol for objects that support probabilities."""
 
     def likelihood(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         """Elementwise likelihood of the model.
 
@@ -203,7 +207,11 @@ class Probabilities(Protocol[Array]):
         ...
 
     def prior(
-        self, mpars: Params[Array], data: Data[Array], current_lnp: Array | None = None
+        self,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        current_lnp: Array | None = None,
     ) -> Array:
         """Elementwise prior.
 
@@ -223,7 +231,9 @@ class Probabilities(Protocol[Array]):
         """
         ...
 
-    def posterior(self, mpars: Params[Array], data: Data[Array], **kw: Array) -> Array:
+    def posterior(
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
+    ) -> Array:
         """Elementwise posterior.
 
         Parameters
@@ -247,7 +257,7 @@ class TotalProbabilities(Protocol[Array]):
     """Protocol for objects that support total probabilities."""
 
     def likelihood_tot(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         """Total likelihood of the model.
 
@@ -269,7 +279,7 @@ class TotalProbabilities(Protocol[Array]):
         """
         ...
 
-    def prior_tot(self, mpars: Params[Array], data: Data[Array]) -> Array:
+    def prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
         """Total prior.
 
         Parameters
@@ -287,7 +297,7 @@ class TotalProbabilities(Protocol[Array]):
         ...
 
     def posterior_tot(
-        self, mpars: Params[Array], data: Data[Array], **kw: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
         """Total posterior.
 

--- a/src/stream_ml/core/_core/api.py
+++ b/src/stream_ml/core/_core/api.py
@@ -9,13 +9,10 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, Protocol, overload
 
 from stream_ml.core._api import (
+    AllProbabilities as AllProbabilitiesAPI,
     HasName,
-    LnProbabilities,
-    Probabilities,
     SupportsXP,
     SupportsXPNN,
-    TotalLnProbabilities,
-    TotalProbabilities,
 )
 from stream_ml.core.params._field import ModelParametersField
 from stream_ml.core.params._values import Params, freeze_params, set_param
@@ -29,11 +26,64 @@ if TYPE_CHECKING:
     from stream_ml.core.typing import BoundsT, ParamNameAllOpts, ParamsLikeDict
 
 
+class AllProbabilities(AllProbabilitiesAPI[Array], SupportsXP[Array], Protocol):
+    # -------------------------------------------
+
+    def ln_likelihood_tot(
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
+    ) -> Array:
+        return self.xp.sum(self.ln_likelihood(mpars, data, **kwargs))
+
+    def ln_prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
+        return self.xp.sum(self.ln_prior(mpars, data))
+
+    def ln_posterior_tot(
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
+    ) -> Array:
+        return self.xp.sum(self.ln_posterior(mpars, data, **kw))
+
+    # -------------------------------------------
+
+    def likelihood(
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
+    ) -> Array:
+        return self.xp.exp(self.ln_likelihood(mpars, data, **kwargs))
+
+    def prior(
+        self,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        current_lnp: Array | None = None,
+    ) -> Array:
+        return self.xp.exp(self.ln_prior(mpars, data, current_lnp))
+
+    def posterior(
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
+    ) -> Array:
+        return self.xp.exp(self.ln_posterior(mpars, data, **kw))
+
+    # -------------------------------------------
+
+    def likelihood_tot(
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
+    ) -> Array:
+        return self.xp.exp(self.ln_likelihood_tot(mpars, data, **kwargs))
+
+    def prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
+        return self.xp.exp(self.ln_prior_tot(mpars, data))
+
+    def posterior_tot(
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
+    ) -> Array:
+        return self.xp.exp(self.ln_posterior_tot(mpars, data, **kw))
+
+
+# ============================================================================
+
+
 class Model(
-    TotalProbabilities[Array],
-    Probabilities[Array],
-    TotalLnProbabilities[Array],
-    LnProbabilities[Array],
+    AllProbabilities[Array],
     SupportsXPNN[Array, NNModel],
     SupportsXP[Array],
     HasName,
@@ -283,60 +333,6 @@ class Model(
         return self.xp.concatenate(
             tuple(self.xp.atleast_1d(mpars[elt]) for elt in self.params.flatskeys())
         )
-
-    # ========================================================================
-    # Statistics
-
-    def ln_likelihood_tot(
-        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
-    ) -> Array:
-        return self.xp.sum(self.ln_likelihood(mpars, data, **kwargs))
-
-    def ln_prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
-        return self.xp.sum(self.ln_prior(mpars, data))
-
-    def ln_posterior_tot(
-        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
-    ) -> Array:
-        return self.xp.sum(self.ln_posterior(mpars, data, **kw))
-
-    # ------------------------------------------------------------------------
-    # Non-logarithmic elementwise versions
-
-    def likelihood(
-        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
-    ) -> Array:
-        return self.xp.exp(self.ln_likelihood(mpars, data, **kwargs))
-
-    def prior(
-        self,
-        mpars: Params[Array],
-        /,
-        data: Data[Array],
-        current_lnp: Array | None = None,
-    ) -> Array:
-        return self.xp.exp(self.ln_prior(mpars, data, current_lnp))
-
-    def posterior(
-        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
-    ) -> Array:
-        return self.xp.exp(self.ln_posterior(mpars, data, **kw))
-
-    # ------------------------------------------------------------------------
-    # Non-logarithmic scalar versions
-
-    def likelihood_tot(
-        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
-    ) -> Array:
-        return self.xp.exp(self.ln_likelihood_tot(mpars, data, **kwargs))
-
-    def prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
-        return self.xp.exp(self.ln_prior_tot(mpars, data))
-
-    def posterior_tot(
-        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
-    ) -> Array:
-        return self.xp.exp(self.ln_posterior_tot(mpars, data, **kw))
 
     # ========================================================================
     # ML

--- a/src/stream_ml/core/_core/api.py
+++ b/src/stream_ml/core/_core/api.py
@@ -288,15 +288,15 @@ class Model(
     # Statistics
 
     def ln_likelihood_tot(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         return self.xp.sum(self.ln_likelihood(mpars, data, **kwargs))
 
-    def ln_prior_tot(self, mpars: Params[Array], data: Data[Array]) -> Array:
+    def ln_prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
         return self.xp.sum(self.ln_prior(mpars, data))
 
     def ln_posterior_tot(
-        self, mpars: Params[Array], data: Data[Array], **kw: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
         return self.xp.sum(self.ln_posterior(mpars, data, **kw))
 
@@ -304,31 +304,37 @@ class Model(
     # Non-logarithmic elementwise versions
 
     def likelihood(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         return self.xp.exp(self.ln_likelihood(mpars, data, **kwargs))
 
     def prior(
-        self, mpars: Params[Array], data: Data[Array], current_lnp: Array | None = None
+        self,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        current_lnp: Array | None = None,
     ) -> Array:
         return self.xp.exp(self.ln_prior(mpars, data, current_lnp))
 
-    def posterior(self, mpars: Params[Array], data: Data[Array], **kw: Array) -> Array:
+    def posterior(
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
+    ) -> Array:
         return self.xp.exp(self.ln_posterior(mpars, data, **kw))
 
     # ------------------------------------------------------------------------
     # Non-logarithmic scalar versions
 
     def likelihood_tot(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         return self.xp.exp(self.ln_likelihood_tot(mpars, data, **kwargs))
 
-    def prior_tot(self, mpars: Params[Array], data: Data[Array]) -> Array:
+    def prior_tot(self, mpars: Params[Array], /, data: Data[Array]) -> Array:
         return self.xp.exp(self.ln_prior_tot(mpars, data))
 
     def posterior_tot(
-        self, mpars: Params[Array], data: Data[Array], **kw: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kw: Array
     ) -> Array:
         return self.xp.exp(self.ln_posterior_tot(mpars, data, **kw))
 

--- a/src/stream_ml/core/_multi/bases.py
+++ b/src/stream_ml/core/_multi/bases.py
@@ -50,10 +50,16 @@ class UnpackParamsCallable(Protocol[Array]):
         ...
 
 
+class SupportsComponentGetItem(Protocol[Array, NNModel]):
+    def __getitem__(self, key: str) -> Model[Array, NNModel]:
+        ...
+
+
 @dataclass
 class ModelsBase(
     Model[Array, NNModel],
     Mapping[str, Model[Array, NNModel]],
+    SupportsComponentGetItem[Array, NNModel],
     CompiledShim,
     metaclass=ABCMeta,
 ):

--- a/src/stream_ml/core/_multi/independent.py
+++ b/src/stream_ml/core/_multi/independent.py
@@ -176,7 +176,7 @@ class IndependentModels(ModelsBase[Array, NNModel]):
     # Statistics
 
     def ln_likelihood(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         """Log likelihood.
 

--- a/src/stream_ml/core/_multi/mixture.py
+++ b/src/stream_ml/core/_multi/mixture.py
@@ -211,11 +211,12 @@ class MixtureModel(ModelsBase[Array, NNModel]):
     # ===============================================================
 
     def ln_likelihood(
-        self, mpars: Params[Array], data: Data[Array], **kwargs: Array
+        self, mpars: Params[Array], /, data: Data[Array], **kwargs: Array
     ) -> Array:
         """Log likelihood.
 
-        Just the log-sum-exp of the individual log-likelihoods.
+        Just the log-sum-exp of the individual log-likelihoods, including the
+        weights.
 
         Parameters
         ----------

--- a/src/stream_ml/core/_multi/mixture.py
+++ b/src/stream_ml/core/_multi/mixture.py
@@ -8,7 +8,8 @@ from dataclasses import KW_ONLY, dataclass
 from typing import TYPE_CHECKING, Literal, cast, overload
 
 from stream_ml.core import NNField
-from stream_ml.core._multi.bases import ModelsBase
+from stream_ml.core._api import SupportsXP
+from stream_ml.core._multi.bases import ModelsBase, SupportsComponentGetItem
 from stream_ml.core.params import (
     ModelParameter,
     ModelParameters,
@@ -30,8 +31,259 @@ if TYPE_CHECKING:
     from stream_ml.core.utils.frozen_dict import FrozenDict
 
 
+class ComponentAllProbabilities(
+    SupportsXP[Array], SupportsComponentGetItem[Array, NNModel]
+):
+    def component_ln_likelihood(
+        self,
+        component: str,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        **kwargs: Array,
+    ) -> Array:
+        """Log-likelihood of a component, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self[component].ln_likelihood(
+            mpars.get_prefixed(component),
+            data,
+            **get_prefixed_kwargs(component, kwargs),
+        ) + self.xp.log(mpars[(f"{component}.weight",)])
+
+    def component_ln_posterior(
+        self,
+        component: str,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        **kwargs: Array,
+    ) -> Array:
+        """Log-posterior of a component, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self[component].ln_posterior(
+            mpars.get_prefixed(component),
+            data,
+            **get_prefixed_kwargs(component, kwargs),
+        ) + self.xp.log(mpars[(f"{component}.weight",)])
+
+    # ----------------------------------------------------------------
+
+    def component_ln_likelihood_tot(
+        self,
+        component: str,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        **kwargs: Array,
+    ) -> Array:
+        """Sum of the component log-likelihood, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.sum(
+            self.component_ln_likelihood(component, mpars, data, **kwargs)
+        )
+
+    def component_ln_posterior_tot(
+        self,
+        component: str,
+        mpars: Params[Array],
+        /,
+        data: Data[Array],
+        **kwargs: Array,
+    ) -> Array:
+        """Sum of the component log-posterior, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.sum(
+            self.component_ln_posterior(component, mpars, data, **kwargs)
+        )
+
+    # ----------------------------------------------------------------
+
+    def component_likelihood(
+        self, component: str, mpars: Params[Array], data: Data[Array], **kwargs: Array
+    ) -> Array:
+        """Likelihood of a component, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.exp(
+            self.component_ln_likelihood(component, mpars, data, **kwargs)
+        )
+
+    def component_posterior(
+        self, component: str, mpars: Params[Array], data: Data[Array], **kwargs: Array
+    ) -> Array:
+        """Posterior of a component, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.exp(
+            self.component_ln_posterior(component, mpars, data, **kwargs)
+        )
+
+    # ----------------------------------------------------------------
+
+    def component_likelihood_tot(
+        self, component: str, mpars: Params[Array], data: Data[Array], **kwargs: Array
+    ) -> Array:
+        """Sum of the component likelihood, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.sum(self.component_likelihood(component, mpars, data, **kwargs))
+
+    def component_posterior_tot(
+        self, component: str, mpars: Params[Array], data: Data[Array], **kwargs: Array
+    ) -> Array:
+        """Sum of the component posterior, including the weight.
+
+        Parameters
+        ----------
+        component : str, positional-only
+            Component name.
+        mpars : Params[Array], positional-only
+            Model parameters. Note that these are different from the ML
+            parameters.
+        data : Data[Array], positional-only
+            Data.
+
+        **kwargs : Array
+            Additional arguments, passed to the component's
+            :meth:`~stream_ml.core.ModelAPI.ln_likelihood``.
+
+        Returns
+        -------
+        Array
+        """
+        return self.xp.sum(self.component_posterior(component, mpars, data, **kwargs))
+
+
+# ============================================================================
+
+
 @dataclass
-class MixtureModel(ModelsBase[Array, NNModel]):
+class MixtureModel(
+    ModelsBase[Array, NNModel], ComponentAllProbabilities[Array, NNModel]
+):
     """Full Model.
 
     Parameters
@@ -234,14 +486,9 @@ class MixtureModel(ModelsBase[Array, NNModel]):
         """
         # Get the parameters for each model, stripping the model name,
         # and use that to evaluate the log likelihood for the model.
-        lnliks = tuple(
-            self.xp.log(mpars[(f"{name}.weight",)])
-            + model.ln_likelihood(
-                mpars.get_prefixed(name),
-                data,
-                **get_prefixed_kwargs(name, kwargs),
-            )
-            for name, model in self.components.items()
+        lnliks = (
+            self.component_ln_likelihood(name, mpars, data, **kwargs)
+            for name in self.components
         )
         # Sum over the models, keeping the data dimension
-        return self.xp.logsumexp(self.xp.hstack(lnliks), 1)[:, None]
+        return self.xp.logsumexp(self.xp.hstack(tuple(lnliks)), 1)[:, None]

--- a/src/stream_ml/core/builtin/_uniform.py
+++ b/src/stream_ml/core/builtin/_uniform.py
@@ -45,6 +45,7 @@ class Uniform(ModelBase[Array, NNModel]):
     def ln_likelihood(
         self,
         mpars: Params[Array],
+        /,
         data: Data[Array],
         *,
         mask: Data[Array] | None = None,


### PR DESCRIPTION
Add methods to include the weight when calculating the probability of a mixture component.
Mixtures carry the weight and include it in the probability calculation. The component distributions do not include the weight in the likelihood calculation. These methods calculate the prob for an individual component, including the mixture weight.