### PR TITLE
don't require all coords to be present in the data

### DIFF
--- a/src/stream_ml/core/_core/base.py
+++ b/src/stream_ml/core/_core/base.py
@@ -250,7 +250,13 @@ class ModelBase(Model[Array, NNModel], CompiledShim, metaclass=ABCMeta):
         shape = data.array.shape[:1] + data.array.shape[2:]
         where = reduce(
             self.xp.logical_or,
-            (~within_bounds(data[k], *v) for k, v in self.coord_bounds.items()),
+            (
+                ~within_bounds(data[k], *v)
+                for k, v in self.coord_bounds.items()
+                if k in data.names
+                # don't require all coordinates to be present in the data,
+                # e.g. "distmod" on an isochrone model.
+            ),
             self.xp.zeros(shape, dtype=bool),
         )
         return self.xp.where(


### PR DESCRIPTION
This is assumed in the priors, but isn't necessary.
In particular, the isochrone often uses "distmod", which isn't a coordinate in the data.