### PR TITLE
ASTYPE_REGISTRY is public in a private module

### DIFF
--- a/src/stream_ml/core/utils/scale/_api.py
+++ b/src/stream_ml/core/utils/scale/_api.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-__all__: list[str] = []
+__all__: list[str] = ["ASTYPE_REGISTRY"]
+# ASTYPE_REGISTRY is public in this private module.
 
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 


### PR DESCRIPTION
Needed for registering methods to `astype`.